### PR TITLE
Documentado de mÃtodos

### DIFF
--- a/agora_tally/tally.py
+++ b/agora_tally/tally.py
@@ -53,6 +53,9 @@ def do_tartally(tally_path):
     return do_tally(dir_path, questions)
 
 def do_dirtally(dir_path, ignore_invalid_votes=False, encrypted_invalid_votes=0):
+    """SOD: do_dirtally receives the path of the file where a determinate json is and returns the out
+    value of the method do_tally (a dictionary where the pars key/value are questions/number of votes)
+    from the file questions_json"""
     res_path = os.path.join(dir_path, 'questions_json')
     with codecs.open(res_path, encoding='utf-8', mode='r') as res_f:
         questions = json.loads(res_f.read())
@@ -64,6 +67,9 @@ def do_dirtally(dir_path, ignore_invalid_votes=False, encrypted_invalid_votes=0)
 def do_tally(dir_path, questions, tallies=[], ignore_invalid_votes=False,
              encrypted_invalid_votes=0, monkey_patcher=None,
              question_indexes=None, withdrawals=[]):
+    """SOD: do_tally method analyses the questions_json file and, with the data about its attributes,
+    returns a dictionary in which the par key-value is a question and its number of votes"""
+
     # questions is in the same format as get_questions_pretty(). Initialized here
     questions = copy.deepcopy(questions)
     base_vote =[dict(choices=[]) for q in questions]

--- a/test/test.py
+++ b/test/test.py
@@ -97,9 +97,12 @@ class TestSequenceFunctions(unittest.TestCase):
 
 
     def _test_method(self, dirname):
-        '''
-        Generic method to do a tally
-        '''
+        """Agora-Voting:  Generic method to do a tally
+        SOD: this method compares the results of applies do_dirtally method to a specific questions_json (in the
+        path determined from tally_path) with the results save in the results_json file and, if they are the same
+        result, returns one of them (in the method, it returns the variable called results but it could be
+        should_results too)"""
+
         tally_path = os.path.join(self.FIXTURES_PATH, dirname)
         results_path = os.path.join(tally_path, "results_json")
         results = do_dirtally(tally_path)


### PR DESCRIPTION
Se han documentado los métodos do_tally y do_dirtally de tally.py, así como el método _test_method de test.py.
En la documentación se han especificado las siglas de la persona que
documenta para mayor facilidad a la hora de diferenciar los comentarios de
Agora-Voting con los de cada uno de los miembros del equipo de trabajo.
