### PR TITLE
Meek-stv test por consola

### DIFF
--- a/agora_tally/tally.py
+++ b/agora_tally/tally.py
@@ -77,7 +77,9 @@ def do_tally(dir_path, questions, tallies=[], ignore_invalid_votes=False,
     # setup the initial data common to all voting system
     i = 0
     for qindex, question in enumerate(questions):
-
+        # SOD: tally_type receives the string which determined the type of tally, we are working over meek-stv module
+        # so, in our specific case, this value must be meek-stv. With this tally_type, the system can check the
+        # counting method with get_voting_system_by_id
         tally_type = question['tally_type']
         voting_system = get_voting_system_by_id(tally_type)
         tally = voting_system.create_tally(None, i)
@@ -135,6 +137,8 @@ def do_tally(dir_path, questions, tallies=[], ignore_invalid_votes=False,
                     # because number 0 cannot be encrypted with elgammal
                     # so we trim beginning and end, parse the int and
                     # substract one
+                    # SOD: number attribute is defined after recovering the vote's value. Remember that the system uses
+                    # a method to encrypted the vote's value to guarantee the homogeneity in the vote's structure
                     number = int(line[1:-2]) - 1
                     choices = tally.parse_vote(number, question, q_withdrawals)
 

--- a/agora_tally/voting_systems/base_stv.py
+++ b/agora_tally/voting_systems/base_stv.py
@@ -120,6 +120,7 @@ class BaseSTVTally(BaseTally):
         self.num_seats = question['num_seats']
 
         # fill answer to dict
+        # SOD: Assign an index to every question starting with the number 1
         i = 1
         for answer in question['answers']:
             self.answer_to_ids_dict[answer['value']] = i

--- a/test/test.py
+++ b/test/test.py
@@ -180,7 +180,20 @@ class TestSequenceFunctions(unittest.TestCase):
     #    self._test_method(self.BORDA_CUSTOM)
 
     def test_meek_stv(self):
-        self._test_method(self.MEEK_STV)
+        results = self._test_method(self.MEEK_STV)
+        print("MEEK-STV TEST")
+        for question in results['questions']:
+            varQuestion = question['question']
+            varWinners = question['winners']
+            print("Question: " + varQuestion)
+            print("Winners:")
+            i = 1
+            for winner in varWinners:
+                stringI = str(i)
+                print(stringI + ". " + winner)
+                i = i+1
+        print("")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Se ha modificado el test de meek-stv para que muestre los resultados de la
votacion por pantalla, ademas de incluir nuevos comentarios en tally.py y
uno mas en base-stv (todos como SOD)
