### PR TITLE
Fix #13 - Solucianada la cuenta de votos en blanco

### DIFF
--- a/agora_tally/voting_systems/base_stv.py
+++ b/agora_tally/voting_systems/base_stv.py
@@ -9,6 +9,7 @@ import sys
 import codecs
 import os
 import tempfile
+import base
 
 from openstv.ballots import Ballots
 from openstv.plugins import getMethodPlugins
@@ -105,7 +106,7 @@ class BaseSTVTally(BaseTally):
                 option_str = question['answers'][option]['value']
             if option >= len(question['answers']):
                 # invalid/blank vote
-                raise Exception()
+                raise base.BlankVoteException()
             ret.append(option_str)
 
         return ret


### PR DESCRIPTION
Ahora los votos que no son nulos pero si salen del rango de posibilidades
se cuentan como blancos al llamar a la excepción concreta para los votos
en blanco en lugar de la excepción por defecto.
